### PR TITLE
feat: file usages example

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,14 @@
     "onCommand:els.runInEmberCLI"
   ],
   "contributes": {
+    "views": {
+      "explorer": [
+        {
+          "id": "els.fileUsages",
+          "name": "Ember File Usages"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "els.runInEmberCLI",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides features like auto complete, goto definition and diagnostics for Ember.js projects",
   "author": "Thomas Sauer <t-sauer@outlook.de>, Aleksandr Kanunnikov <lifeart92@gmail.com>",
   "license": "MIT",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "publisher": "lifeart",
   "icon": "icon.png",
   "keywords": [
@@ -89,7 +89,7 @@
     "vscode": "^1.1.29"
   },
   "dependencies": {
-    "@emberwatch/ember-language-server": "lifeart/ember-language-server#983e9dda29bea64728a211621a95ccc6de59ab9f",
+    "@emberwatch/ember-language-server": "lifeart/ember-language-server#16cc6cbc4bf09d7d336e8566427abdb66bbfaa7c",
     "vscode-languageclient": "^6.1.1"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,5 +5,6 @@ export const COMMANDS = {
     RUN_IN_EMBER_CLI: 'els.runInEmberCLI',
     EXECUTE_IN_EMBER_CLI: 'els.executeInEmberCLI',
     SET_CONFIG: 'els.setConfig',
-    GET_RELATED_FILES: 'els.getRelatedFiles'
+    GET_RELATED_FILES: 'els.getRelatedFiles',
+    GET_KIND_USAGES: 'els.getKindUsages'
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@
 
 import * as path from "path";
 import { COMMANDS as ELS_COMMANDS } from './constants';
+import { UsagesProvider } from './usages-provider';
 import {
   workspace,
   ExtensionContext,
@@ -121,9 +122,22 @@ export async function activate(context: ExtensionContext) {
     clientOptions
   );
 
+  const fileUsagesProvider = new UsagesProvider();
+
+
   disposable.onReady().then(() => {
     commands.executeCommand(ELS_COMMANDS.SET_CONFIG, config);
     ExtStatusBarItem.text = "$(telescope) " + 'Ember';
+
+    window.onDidChangeActiveTextEditor(()=>{
+      if (window.activeTextEditor) {
+        fileUsagesProvider.refresh();
+      }
+    });
+    window.createTreeView('els.fileUsages', {
+      treeDataProvider: fileUsagesProvider
+    });
+
   });
   context.subscriptions.push(disposable.start());
 
@@ -132,7 +146,7 @@ export async function activate(context: ExtensionContext) {
     commands.executeCommand("vscode.open", url);
   }
 
- 
+
 
   if (config.codeLens.relatedFiles) {
     const langs = [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,9 +134,10 @@ export async function activate(context: ExtensionContext) {
         fileUsagesProvider.refresh();
       }
     });
-    window.createTreeView('els.fileUsages', {
+    let treeView = window.createTreeView('els.fileUsages', {
       treeDataProvider: fileUsagesProvider
     });
+    fileUsagesProvider.setView(treeView);
 
   });
   context.subscriptions.push(disposable.start());

--- a/src/usages-provider.ts
+++ b/src/usages-provider.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import { COMMANDS as ELS_COMMANDS } from './constants';
+
+
+export class UsagesProvider implements vscode.TreeDataProvider<Dependency> {
+  constructor() { }
+
+  private _onDidChangeTreeData: vscode.EventEmitter<Dependency | undefined> = new vscode.EventEmitter<Dependency | undefined>();
+  readonly onDidChangeTreeData: vscode.Event<Dependency | undefined> = this._onDidChangeTreeData.event;
+
+  refresh() {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: Dependency): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: Dependency): Promise<Dependency[]> {
+    if (element) {
+      return [];
+    } else {
+      const files = await vscode.commands.executeCommand(ELS_COMMANDS.GET_RELATED_FILES, vscode.window.activeTextEditor.document.uri.fsPath);
+      if (files) {
+        const result = await this.getDeps(files as string[]);
+        return result;
+      } else {
+        return [];
+      }
+    }
+  }
+
+  /**
+   * Given the path to package.json, read all its dependencies and devDependencies.
+   */
+  private getDeps(relatedFiles: string[]): Dependency[] {
+    return relatedFiles.map((filePath) => {
+      const normalized = filePath.split('\\').join('/');
+      const name = normalized.split('/').pop();
+      return new Dependency(name, normalized, vscode.TreeItemCollapsibleState.None);
+    });
+  }
+}
+
+class Dependency extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    private fullPath: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+  ) {
+    super(label, collapsibleState);
+  }
+
+
+  get tooltip(): string {
+    return `${this.label}-${this.fullPath}`;
+  }
+
+  get contextValue() {
+    return 'file';
+  }
+
+  get description(): string {
+    return this.fullPath;
+  }
+  get command(): vscode.Command {
+    return {
+      title: '',
+      tooltip: 'Open file',
+      command: 'vscode.open',
+      arguments: [this.resourceUri]
+    }
+  }
+
+  get resourceUri(): vscode.Uri {
+    return vscode.Uri.file(this.fullPath);
+  }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -791,9 +791,9 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@emberwatch/ember-language-server@lifeart/ember-language-server#983e9dda29bea64728a211621a95ccc6de59ab9f":
+"@emberwatch/ember-language-server@lifeart/ember-language-server#16cc6cbc4bf09d7d336e8566427abdb66bbfaa7c":
   version "0.2.2"
-  resolved "https://codeload.github.com/lifeart/ember-language-server/tar.gz/983e9dda29bea64728a211621a95ccc6de59ab9f"
+  resolved "https://codeload.github.com/lifeart/ember-language-server/tar.gz/16cc6cbc4bf09d7d336e8566427abdb66bbfaa7c"
   dependencies:
     "@glimmer/syntax" "^0.52.0"
     ast-types "^0.13.3"


### PR DESCRIPTION
changes, needed in language-server
- [x] make "els.fileUsages" command, returning current file meta + it's usages

```ts
interface Usage {
   name: "my-component/foo",
   path: "c:/.../components/foo.js",
   type: "component",
   usages: Usage[]
}
```


![image](https://user-images.githubusercontent.com/1360552/80895297-f131d700-8ceb-11ea-9e7b-15af87ef3d8f.png)

https://github.com/lifeart/ember-language-server/pull/86
https://code.visualstudio.com/api/references/vscode-api#TreeView