### PR TITLE
Add checking availability `Execute ember-cli command`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,15 @@
         {
           "id": "els.fileUsages",
           "name": "Ember File Usages",
-          "when": "emberFileUsagesEnabled"
+          "when": "vscode-ember-unstable.emberFileUsagesEnabled"
         }
       ]
     },
     "commands": [
       {
         "command": "els.runInEmberCLI",
-        "title": "Ember: Execute ember-cli command"
+        "title": "Ember: Execute ember-cli command",
+        "enablement": "vscode-ember-unstable.emberFastCliAvailable"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,11 @@ import {
   StatusBarAlignment,
   Uri,
 } from 'vscode';
-import { isEmberCliProject, isGlimmerXProject } from './workspace-utils';
+import {
+  isEmberCliProject,
+  isGlimmerXProject,
+  packageAvailable,
+} from './workspace-utils';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -294,4 +298,12 @@ export async function activate(context: ExtensionContext) {
       );
     });
   }
+
+  const emberFastCliAvailable = await packageAvailable('ember-fast-cli');
+
+  commands.executeCommand(
+    'setContext',
+    'vscode-ember-unstable.emberFastCliAvailable',
+    emberFastCliAvailable
+  );
 }

--- a/src/usages-provider.ts
+++ b/src/usages-provider.ts
@@ -37,7 +37,7 @@ export class UsagesProvider implements vscode.TreeDataProvider<Dependency> {
 
         vscode.commands.executeCommand(
           'setContext',
-          'emberFileUsagesEnabled',
+          'vscode-ember-unstable.emberFileUsagesEnabled',
           enabled
         );
 
@@ -48,7 +48,7 @@ export class UsagesProvider implements vscode.TreeDataProvider<Dependency> {
     } else {
       vscode.commands.executeCommand(
         'setContext',
-        'emberFileUsagesEnabled',
+        'vscode-ember-unstable.emberFileUsagesEnabled',
         false
       );
     }

--- a/src/workspace-utils.ts
+++ b/src/workspace-utils.ts
@@ -19,3 +19,13 @@ export async function isEmberCliProject(): Promise<boolean> {
 
   return emberCliBuildFile.length > 0;
 }
+
+export async function packageAvailable(packageName: string): Promise<boolean> {
+  const files = await workspace.findFiles(
+    `**/node_modules/${packageName}/package.json`,
+    null,
+    1
+  );
+
+  return files.length > 0;
+}


### PR DESCRIPTION
This PR checks that the `ember-fast-cli` package is installed or not and shows the command `Ember: Execute ember-cli command` or doesn't.